### PR TITLE
Update MAURConfig.m

### DIFF
--- a/ios/common/BackgroundGeolocation/MAURConfig.m
+++ b/ios/common/BackgroundGeolocation/MAURConfig.m
@@ -362,13 +362,13 @@
 
 - (CLActivityType) decodeActivityType
 {
-    if ([activityType caseInsensitiveCompare:@"AutomotiveNavigation"]) {
+    if ([activityType caseInsensitiveCompare:@"AutomotiveNavigation"] == NSOrderedSame) {
         return CLActivityTypeAutomotiveNavigation;
     }
-    if ([activityType caseInsensitiveCompare:@"OtherNavigation"]) {
+    if ([activityType caseInsensitiveCompare:@"OtherNavigation"] == NSOrderedSame) {
         return CLActivityTypeOtherNavigation;
     }
-    if ([activityType caseInsensitiveCompare:@"Fitness"]) {
+    if ([activityType caseInsensitiveCompare:@"Fitness"] == NSOrderedSame) {
         return CLActivityTypeFitness;
     }
 


### PR DESCRIPTION
This is a bug fis. It's pretty critical and can cause a lot of headache, did for me. You can get road snapping when you don't want to for example, ie Fitness activity type becomes AutomotiveNavigation.

String comparisons in MAURConfig.m look like this now:
if ([activityType caseInsensitiveCompare:@"AutomotiveNavigation"]) {
return CLActivityTypeAutomotiveNavigation;
}

but that actually means "if string NOT matches". It should instead be

if ([activityType caseInsensitiveCompare:@"AutomotiveNavigation"] == NSOrderedSame) {
return CLActivityTypeAutomotiveNavigation;
}