### PR TITLE
Fix import sqlite

### DIFF
--- a/ios/common/BackgroundGeolocation/MAURSQLiteConfigurationDAO.m
+++ b/ios/common/BackgroundGeolocation/MAURSQLiteConfigurationDAO.m
@@ -6,7 +6,7 @@
 //  Copyright © 2017 mauron85. All rights reserved.
 //
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import <CoreLocation/CoreLocation.h>
 #import "MAURSQLiteHelper.h"
 #import "MAURGeolocationOpenHelper.h"

--- a/ios/common/BackgroundGeolocation/MAURSQLiteLocationDAO.m
+++ b/ios/common/BackgroundGeolocation/MAURSQLiteLocationDAO.m
@@ -5,7 +5,7 @@
 //  Created by Marian Hello on 10/06/16.
 //
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import <CoreLocation/CoreLocation.h>
 #import "MAURSQLiteHelper.h"
 #import "MAURGeolocationOpenHelper.h"


### PR DESCRIPTION
This can collide with other plugins and so the solution is to use "<" instead of '"' to import sqlite header.