### PR TITLE
Fixed onCreate issue Android 12

### DIFF
--- a/android/common/src/main/java/com/marianhello/bgloc/provider/DistanceFilterLocationProvider.java
+++ b/android/common/src/main/java/com/marianhello/bgloc/provider/DistanceFilterLocationProvider.java
@@ -85,20 +85,28 @@ public class DistanceFilterLocationProvider extends AbstractLocationProvider imp
         locationManager = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
         alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
 
+        int zeroFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            ? 0 | PendingIntent.FLAG_MUTABLE
+            : 0;
+
+        int cancelCurrentFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            ? PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE
+            : PendingIntent.FLAG_CANCEL_CURRENT;
+
         // Stop-detection PI
-        stationaryAlarmPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_ALARM_ACTION), 0);
+        stationaryAlarmPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_ALARM_ACTION), zeroFlag);
         registerReceiver(stationaryAlarmReceiver, new IntentFilter(STATIONARY_ALARM_ACTION));
 
         // Stationary region PI
-        stationaryRegionPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_REGION_ACTION), PendingIntent.FLAG_CANCEL_CURRENT);
+        stationaryRegionPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_REGION_ACTION), cancelCurrentFlag);
         registerReceiver(stationaryRegionReceiver, new IntentFilter(STATIONARY_REGION_ACTION));
 
         // Stationary location monitor PI
-        stationaryLocationPollingPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_LOCATION_MONITOR_ACTION), 0);
+        stationaryLocationPollingPI = PendingIntent.getBroadcast(mContext, 0, new Intent(STATIONARY_LOCATION_MONITOR_ACTION), zeroFlag);
         registerReceiver(stationaryLocationMonitorReceiver, new IntentFilter(STATIONARY_LOCATION_MONITOR_ACTION));
 
         // One-shot PI (TODO currently unused)
-        singleUpdatePI = PendingIntent.getBroadcast(mContext, 0, new Intent(SINGLE_LOCATION_UPDATE_ACTION), PendingIntent.FLAG_CANCEL_CURRENT);
+        singleUpdatePI = PendingIntent.getBroadcast(mContext, 0, new Intent(SINGLE_LOCATION_UPDATE_ACTION), cancelCurrentFlag);
         registerReceiver(singleUpdateReceiver, new IntentFilter(SINGLE_LOCATION_UPDATE_ACTION));
 
         // Location criteria


### PR DESCRIPTION
Added PendingIntent.FLAG_MUTABLE for PendingIntent objects created in DistanceFilterLocationProvider.

This PR solves the following error on Android 12 apps:

`D/com.marianhello.bgloc.service.LocationServiceImpl: Will start service with: Config[distanceFilter=100 stationaryRadius=100.0 desiredAccuracy=100 interval=300000 fastestInterval=300000 activitiesInterval=300000 isDebugging=false stopOnTerminate=true stopOnStillActivity=false startOnBoot=false startForeground=true notificationsEnabled=true locationProvider=0 nTitle=Tracciamento Posizione nText=enabled nIconLarge= nIconSmall= nIconColor= url= syncUrl= syncThreshold=100 httpHeaders={} maxLocations=20 postTemplate=null]
I/com.marianhello.bgloc.provider.DistanceFilterLocationProvider: Creating DistanceFilterLocationProvider
E/com.marianhello.bgloc.service.LocationServiceImpl: processCommand: exceptionjava.lang.IllegalArgumentException: ****.********.******: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:378)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:648)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:635)
        at com.marianhello.bgloc.provider.DistanceFilterLocationProvider.onCreate(DistanceFilterLocationProvider.java:89)`