### PR TITLE
Use newer ACTIVITY_RECOGNITION permission

### DIFF
--- a/android/CDVBackgroundGeolocation/src/main/AndroidManifest.xml
+++ b/android/CDVBackgroundGeolocation/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -175,7 +175,7 @@
             <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
             <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-            <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
+            <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -175,6 +175,7 @@
             <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
             <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+            <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
             <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
Hi, first of all thanks for keeping original cordova location plugin up to date!

I found an issue on Android 14 where ACTIVITY_RECOGNITION did not appear in app settings, until I changed its name in AndroidManifest, as in this PR.