### PR TITLE
Check for activityRecognitionPermitted in ActivityRecognitionLocationProvider

### DIFF
--- a/android/common/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
+++ b/android/common/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
@@ -5,10 +5,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.location.Location;
+import android.Manifest;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
+import androidx.core.app.ActivityCompat;
 import android.util.Log;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -147,13 +150,17 @@ public class ActivityRecognitionLocationProvider extends AbstractLocationProvide
         }
     }
 
+    private boolean activityRecognitionPermitted() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || ActivityCompat.checkSelfPermission(mContext, Manifest.permission.ACTIVITY_RECOGNITION) == PackageManager.PERMISSION_GRANTED;
+    }
+
     private void attachRecorder() {
         if (googleApiClient == null) {
             connectToPlayAPI();
         } else if (googleApiClient.isConnected()) {
             if (isWatchingActivity) { return; }
             startTracking();
-            if (mConfig.getStopOnStillActivity()) {
+            if (mConfig.getStopOnStillActivity() && activityRecognitionPermitted())) {
                 ActivityRecognition.ActivityRecognitionApi.requestActivityUpdates(
                         googleApiClient,
                         mConfig.getActivitiesInterval(),

--- a/android/common/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
+++ b/android/common/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
@@ -160,7 +160,7 @@ public class ActivityRecognitionLocationProvider extends AbstractLocationProvide
         } else if (googleApiClient.isConnected()) {
             if (isWatchingActivity) { return; }
             startTracking();
-            if (mConfig.getStopOnStillActivity() && activityRecognitionPermitted())) {
+            if (mConfig.getStopOnStillActivity() && activityRecognitionPermitted()) {
                 ActivityRecognition.ActivityRecognitionApi.requestActivityUpdates(
                         googleApiClient,
                         mConfig.getActivitiesInterval(),


### PR DESCRIPTION
Added check for permissions before calling `requestActivityUpdates`. Otherwise, when permission is declined I get:

```
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: FATAL EXCEPTION: mainjava.lang.SecurityException: Activity detection usage requires the ACTIVITY_RECOGNITION permission
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:3183)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at android.os.Parcel.createException(Parcel.java:3167)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at android.os.Parcel.readException(Parcel.java:3150)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at android.os.Parcel.readException(Parcel.java:3092)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.internal.location.zza.zzx(com.google.android.gms:play-services-location@@18.0.0:3)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.internal.location.zzal.zzh(com.google.android.gms:play-services-location@@18.0.0:5)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.internal.location.zzaz.zzq(com.google.android.gms:play-services-location@@18.0.0:4)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.internal.location.zzd.doExecute(com.google.android.gms:play-services-location@@18.0.0:2)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.common.api.internal.BaseImplementation$ApiMethodImpl.run(com.google.android.gms:play-services-base@@18.0.1:1)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.common.api.internal.zaaj.zab(com.google.android.gms:play-services-base@@18.0.1:6)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.common.api.internal.zabi.zaf(com.google.android.gms:play-services-base@@18.0.1:2)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.common.api.internal.zabe.execute(com.google.android.gms:play-services-base@@18.0.1:12)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.internal.location.zzg.requestActivityUpdates(com.google.android.gms:play-services-location@@18.0.0:1)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.marianhello.bgloc.provider.ActivityRecognitionLocationProvider.attachRecorder(ActivityRecognitionLocationProvider.java:160)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.marianhello.bgloc.provider.ActivityRecognitionLocationProvider.onConnected(ActivityRecognitionLocationProvider.java:184)
08-01 15:58:49.895 15460 15460 E com.marianhello.logging.UncaughtExceptionLogger: 	at com.google.android.gms.common.internal.zak.zad(com.google.android.gms:play-services-base@@18.0.1:11)
...
```