### PR TITLE
Update show app settings for IOS 18 support

### DIFF
--- a/ios/common/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
+++ b/ios/common/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
@@ -321,7 +321,10 @@ FMDBLogger *sqliteLogger;
     [self runOnMainThread:^{
         BOOL canGoToSettings = (UIApplicationOpenSettingsURLString != NULL);
         if (canGoToSettings) {
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            [[UIApplication sharedApplication] openURL:settingsURL 
+                                               options:@{} 
+                                     completionHandler:nil];
         }
     }];
 }


### PR DESCRIPTION
### Bug Description
Incase of IOS 17 while executing showAppSettings() it correctly navigates to app settings but in the case if IOS 18 its not working, debugging further got the following error in stream logs,
`BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).`

IOS Logs Image,
![image](https://github.com/user-attachments/assets/7520140d-bf5e-4a17-9230-50b33d18a43d)

### Solution
The bug is actually inherent inside the IOS 18 and the solution is to either use the same openURL method but with overloaded options or use the new open method with correct overloads (which apparently under the hood still calls openURL which makes sense) consider the following discussion thread,
https://developer.apple.com/forums/thread/763568

applying the proposed changes allows us to navigate to app settings in IOS 18 (tested on simulator)
 