### PR TITLE
remove #import <netinet6/in6.h> in Reachability.m

### DIFF
--- a/ios/common/BackgroundGeolocation/Reachability.m
+++ b/ios/common/BackgroundGeolocation/Reachability.m
@@ -29,7 +29,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
## Fix: Remove deprecated netinet6/in6.h import from Reachability.m

  ### Problem
  Building the Cordova plugin with Xcode SDK 26.4 fails with:
  `Use of private header from outside its module: 'netinet6/in6.h'`

  <img width="1040" height="50" alt="image"
  src="https://github.com/user-attachments/assets/57654216-f2fd-4102-8515-38fe9105ec2d" />

  ### Root Cause
  The `netinet6/in6.h` header should not be included directly according to RFC2553. From the header file
  itself:

  ```c
  #ifndef __KAME_NETINET_IN_H_INCLUDED_
  #error "do not include netinet6/in6.h directly, include netinet/in.h. " \
          " see RFC2553"
  #endif
```

  Solution

  Remove the deprecated #import <netinet6/in6.h> import. All necessary definitions (both IPv4 and IPv6)
  are already provided by #import <netinet/in.h>, which is already included in the file.

  Verification

  - ✅ Reachability.m compiles successfully without the import
  - ✅ File only uses IPv4 structures (sockaddr_in, AF_INET) - no IPv6-specific code
  - ✅ All required symbols are available through <netinet/in.h>

  This change follows POSIX standards and modern best practices for network programming on macOS/iOS.