### PR TITLE
Add resource strings to additional file to support Cordova-Android 15

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -194,7 +194,14 @@
             </feature>
         </config-file>
 
+        <!-- For Cordova-Android <15 the resource strings need to be stored in strings.xml-->
         <config-file target="res/values/strings.xml" parent="/resources">
+            <string name="plugin_bgloc_account_name">$ACCOUNT_NAME</string>
+            <string name="plugin_bgloc_account_type">$ACCOUNT_TYPE</string>
+            <string name="plugin_bgloc_content_authority">$CONTENT_AUTHORITY</string>
+        </config-file>
+        <!-- For Cordova-Android >=15 the resource strings need to be stored in cdv_strings.xml-->
+        <config-file target="app/src/main/res/values/cdv_strings.xml" parent="/resources">
             <string name="plugin_bgloc_account_name">$ACCOUNT_NAME</string>
             <string name="plugin_bgloc_account_type">$ACCOUNT_TYPE</string>
             <string name="plugin_bgloc_content_authority">$CONTENT_AUTHORITY</string>


### PR DESCRIPTION
The made change fixes issue #214.
The Cordova CLI no longer generates a strings.xml as of version 15. As a result the build fails because resources cannot be found. To fix this the concerned resource strings are also stored in cdv_strings.xml which is the new filename for storing resource strings, see also [this issue](https://github.com/apache/cordova-android/issues/1922).
I also explored the alternative solution of creating an own separate resource file but this does not work as then the variables are not resolved.